### PR TITLE
-Fixed error where getUser (used for company dropdown) was only allowed for managers and admins. The logged in user should be able to retrive iself

### DIFF
--- a/ProjectLedg.Server/Controllers/UserController.cs
+++ b/ProjectLedg.Server/Controllers/UserController.cs
@@ -37,7 +37,7 @@ namespace ProjectLedg.Server.Controllers
         }
 
         // GET: api/User/{id}
-        [Authorize(Roles = "Manager, Admin")]
+        [Authorize]
         [HttpGet("getUser")]
         public async Task<IActionResult> GetUserByIdAsync()
         {


### PR DESCRIPTION
-Fixed error where getUser (used for company dropdown) was only allowed for managers and admins. The logged in user should be able to retrive iself